### PR TITLE
autotools: make dist should create VERSION

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -100,3 +100,6 @@ include $(top_srcdir)/aminclude_static.am
 
 clean-local: code-coverage-clean
 distclean-local: code-coverage-dist-clean
+
+dist-hook:
+	$(AM_V_GEN)echo $(VERSION) > $(distdir)/VERSION


### PR DESCRIPTION
When creating a release, using `make dist`, the resulting tarballs
do not contain the file `VERSION` - but they need to.

Fixes: #2123
Signed-off-by: Joseph Benden <joe@benden.us>